### PR TITLE
Set the kernel as protected, to give access to parent classes

### DIFF
--- a/src/Ninject.Extensions.Azure/NinjectRoleEntryPoint.cs
+++ b/src/Ninject.Extensions.Azure/NinjectRoleEntryPoint.cs
@@ -14,7 +14,7 @@ namespace Ninject.Extensions.Azure
     /// </summary>
     public abstract class NinjectRoleEntryPoint : RoleEntryPoint
     {
-        private IKernel Kernel { get; set; }
+        protected IKernel Kernel { get; set; }
 
         /// <summary>
         /// Called by Windows Azure to initialize the role instance.


### PR DESCRIPTION
We need access to the kernel in our implementation, this is the cleanest way to do it.
